### PR TITLE
Fix compilation errors for embedded platforms like Xtensa/ESP32

### DIFF
--- a/serde_valid/Cargo.toml
+++ b/serde_valid/Cargo.toml
@@ -16,7 +16,7 @@ fluent_0 = { package = "fluent", version = "0.16.0", optional = true }
 indexmap = { version = "^1.9", features = ["serde", "std"] }
 itertools = "^0.10"
 jsonschema = { version = "^0.16", optional = true }
-num-traits = "^0.2"
+num-traits = { version = "^0.2", features = ["i128"] }
 once_cell = "^1.7"
 paste = { workspace = true }
 regex = { workspace = true }

--- a/serde_valid/Cargo.toml
+++ b/serde_valid/Cargo.toml
@@ -16,7 +16,7 @@ fluent_0 = { package = "fluent", version = "0.16.0", optional = true }
 indexmap = { version = "^1.9", features = ["serde", "std"] }
 itertools = "^0.10"
 jsonschema = { version = "^0.16", optional = true }
-num-traits = { version = "^0.2", features = ["i128"] }
+num-traits = "^0.2"
 once_cell = "^1.7"
 paste = { workspace = true }
 regex = { workspace = true }

--- a/serde_valid/Cargo.toml
+++ b/serde_valid/Cargo.toml
@@ -13,7 +13,7 @@ version.workspace = true
 
 [dependencies]
 fluent_0 = { package = "fluent", version = "0.16.0", optional = true }
-indexmap = { version = "^1.9", features = ["serde"] }
+indexmap = { version = "^1.9", features = ["serde", "std"] }
 itertools = "^0.10"
 jsonschema = { version = "^0.16", optional = true }
 num-traits = "^0.2"

--- a/serde_valid/src/validation/numeric/multiple_of.rs
+++ b/serde_valid/src/validation/numeric/multiple_of.rs
@@ -74,14 +74,12 @@ impl_validate_numeric_multiple_of!(i8);
 impl_validate_numeric_multiple_of!(i16);
 impl_validate_numeric_multiple_of!(i32);
 impl_validate_numeric_multiple_of!(i64);
-#[cfg(feature = "num-traits/i128")]
 impl_validate_numeric_multiple_of!(i128);
 impl_validate_numeric_multiple_of!(isize);
 impl_validate_numeric_multiple_of!(u8);
 impl_validate_numeric_multiple_of!(u16);
 impl_validate_numeric_multiple_of!(u32);
 impl_validate_numeric_multiple_of!(u64);
-#[cfg(feature = "num-traits/i128")]
 impl_validate_numeric_multiple_of!(u128);
 impl_validate_numeric_multiple_of!(usize);
 impl_validate_numeric_multiple_of!(f32);

--- a/serde_valid/src/validation/numeric/multiple_of.rs
+++ b/serde_valid/src/validation/numeric/multiple_of.rs
@@ -74,12 +74,14 @@ impl_validate_numeric_multiple_of!(i8);
 impl_validate_numeric_multiple_of!(i16);
 impl_validate_numeric_multiple_of!(i32);
 impl_validate_numeric_multiple_of!(i64);
+#[cfg(feature = "num-traits/i128")]
 impl_validate_numeric_multiple_of!(i128);
 impl_validate_numeric_multiple_of!(isize);
 impl_validate_numeric_multiple_of!(u8);
 impl_validate_numeric_multiple_of!(u16);
 impl_validate_numeric_multiple_of!(u32);
 impl_validate_numeric_multiple_of!(u64);
+#[cfg(feature = "num-traits/i128")]
 impl_validate_numeric_multiple_of!(u128);
 impl_validate_numeric_multiple_of!(usize);
 impl_validate_numeric_multiple_of!(f32);


### PR DESCRIPTION
serde_valid is a very useful add-on for serde deserializations.

This PR contains changes to compile it for embedded platforms which don't autodetect `std` feature and `i128` feature. Specifically the ESP32 platform.

To compile there, `indexmap` needs feature `std` enabled. In addition `num_traits` won't have the traits for `i128` enabled, so this PR makes the `numeric_multiple_of` validations for 128-bit integers only available if the `i128` feature is enabled and avoids a compilation error if not.
