### PR TITLE
Add recursive implementation of validation to HashMap, leaving max/min properties unchanged

### DIFF
--- a/serde_valid/src/lib.rs
+++ b/serde_valid/src/lib.rs
@@ -442,6 +442,8 @@ pub mod json;
 mod traits;
 pub mod validation;
 
+use std::collections::HashMap;
+
 use indexmap::IndexMap;
 
 pub use error::{
@@ -482,6 +484,29 @@ where
 
         for (index, item) in self.iter().enumerate() {
             if let Err(errors) = item.validate() {
+                items.insert(index, errors);
+            }
+        }
+
+        if items.is_empty() {
+            Ok(())
+        } else {
+            Err(self::validation::Errors::Array(
+                validation::ArrayErrors::new(vec![], items),
+            ))
+        }
+    }
+}
+
+impl<K, V> Validate for HashMap<K, V>
+where
+    V: Validate,
+{
+    fn validate(&self) -> std::result::Result<(), self::validation::Errors> {
+        let mut items = IndexMap::new();
+
+        for (index, (_key, value)) in self.iter().enumerate() {
+            if let Err(errors) = value.validate() {
                 items.insert(index, errors);
             }
         }

--- a/serde_valid/src/lib.rs
+++ b/serde_valid/src/lib.rs
@@ -39,8 +39,10 @@
 //! Serde Valid support standard validation based JSON Schema.
 //!
 //! | Type | Serde Valid(validate derive) | Serde Valid(validate trait) | Json Schema |
-//! | :-----: | :----------------------------------- | :----------------------------------------------------- | :----------------------------------------------------------------------------------------------------- |
-//! | String  | `#[validate(max_length = 5)]`        | [`ValidateMaxLength`](ValidateMaxLength)               | [maxLength](https://json-schema.org/understanding-json-schema/reference/string.html#length)            |
+//! | :-----: | :----------------------------------- |
+//! :----------------------------------------------------- |
+//! :-----------------------------------------------------------------------------------------------------
+//! | | String  | `#[validate(max_length = 5)]`        | [`ValidateMaxLength`](ValidateMaxLength)               | [maxLength](https://json-schema.org/understanding-json-schema/reference/string.html#length)            |
 //! | String  | `#[validate(min_length = 5)]`        | [`ValidateMinLength`](ValidateMinLength)               | [minLength](https://json-schema.org/understanding-json-schema/reference/string.html#length)            |
 //! | String  | `#[validate(pattern = r"^\d{5}$")]`  | [`ValidatePattern`](ValidatePattern)                   | [pattern](https://json-schema.org/understanding-json-schema/reference/string.html#regular-expressions) |
 //! | Numeric | `#[validate(maximum = 5)]`           | [`ValidateMaximum`](ValidateMaximum)                   | [maximum](https://json-schema.org/understanding-json-schema/reference/numeric.html#range)              |
@@ -57,7 +59,8 @@
 //!
 //! ## Complete Constructor (Deserialization)
 //!
-//! Serde Valid support complete constructor method using by [`serde_valid::json::FromJsonValue`](json::FromJsonValue) trait.
+//! Serde Valid support complete constructor method using by
+//! [`serde_valid::json::FromJsonValue`](json::FromJsonValue) trait.
 //!
 //! ```rust
 //! use serde::Deserialize;
@@ -87,7 +90,8 @@
 //! );
 //! ```
 //!
-//! You can force validation by only deserialization through `serde_valid`, and removing `serde_json` from `Cargo.toml` of your project.
+//! You can force validation by only deserialization through `serde_valid`, and removing
+//! `serde_json` from `Cargo.toml` of your project.
 //!
 //! ## Serialization
 //!
@@ -287,7 +291,8 @@
 //! ```
 //!
 //! ### Unnamed Struct
-//! Field errors are output to `items`. The key for `items` is guaranteed to be a string of positive numbers.
+//! Field errors are output to `items`. The key for `items` is guaranteed to be a string of positive
+//! numbers.
 //!
 //! ```rust
 //! use serde_json::json;
@@ -378,7 +383,8 @@
 //! ```
 //!
 //! ### Unnamed Enum
-//! Variant errors are output to `items`. The key for `items` is guaranteed to be a string of positive numbers.
+//! Variant errors are output to `items`. The key for `items` is guaranteed to be a string of
+//! positive numbers.
 //!
 //! ```rust
 //! use serde_json::json;
@@ -498,24 +504,24 @@ where
     }
 }
 
-impl<K, V> Validate for HashMap<K, V>
+impl<V> Validate for HashMap<&'static str, V>
 where
     V: Validate,
 {
     fn validate(&self) -> std::result::Result<(), self::validation::Errors> {
         let mut items = IndexMap::new();
 
-        for (index, (_key, value)) in self.iter().enumerate() {
+        for (key, value) in self.iter() {
             if let Err(errors) = value.validate() {
-                items.insert(index, errors);
+                items.insert(*key, errors);
             }
         }
 
         if items.is_empty() {
             Ok(())
         } else {
-            Err(self::validation::Errors::Array(
-                validation::ArrayErrors::new(vec![], items),
+            Err(self::validation::Errors::Object(
+                validation::ObjectErrors::new(vec![], items),
             ))
         }
     }

--- a/serde_valid/tests/hashmap_test.rs
+++ b/serde_valid/tests/hashmap_test.rs
@@ -1,0 +1,102 @@
+use regex::Regex;
+use serde_json::json;
+use serde_valid::Validate;
+use std::collections::HashMap;
+
+#[derive(Debug, Validate)]
+struct TestStruct {
+    // Numeric validator
+    #[validate(multiple_of = 5)]
+    #[validate(minimum = 5)]
+    #[validate(maximum = 20)]
+    #[validate(exclusive_minimum = 4)]
+    #[validate(exclusive_maximum = 21)]
+    // Checks hashmap not number
+    #[validate(max_properties = 2)]
+    #[validate(min_properties = 2)]
+    hashmap_of_hashmap: HashMap<String, HashMap<String, i32>>,
+
+    // Generic validator
+    #[validate(enumerate(5, 10, 15))]
+    // Numeric validator
+    #[validate(multiple_of = 5)]
+    #[validate(minimum = 5)]
+    #[validate(maximum = 10)]
+    #[validate(exclusive_minimum = 4)]
+    #[validate(exclusive_maximum = 11)]
+    // Checks hashmap not number
+    #[validate(max_properties = 2)]
+    #[validate(min_properties = 2)]
+    hashmap_of_numbers: HashMap<String, i32>,
+
+    #[validate(pattern = "d.*")]
+    #[validate(max_length = 5)]
+    #[validate(min_length = 5)]
+    // Checks hashmap not string
+    #[validate(max_properties = 2)]
+    #[validate(min_properties = 2)]
+    hashmap_of_strings: HashMap<String, String>,
+}
+
+#[test]
+fn hashmap_validation() {
+    // Create basic valid hashmaps.
+    let mut hashmap_of_numbers = HashMap::from([("five".to_string(), 5), ("ten".to_string(), 10)]);
+    let mut hashmap_of_strings = HashMap::from([
+        ("one".to_string(), "ddddd".to_string()),
+        ("two".to_string(), "ddddd".to_string()),
+    ]);
+    let mut hashmap_of_numbers_2 =
+        HashMap::from([("five".to_string(), 5), ("ten".to_string(), 10)]);
+    let mut hashmap_of_hashmap = HashMap::from([
+        ("H_One".to_string(), hashmap_of_numbers.clone()),
+        ("H_two".to_string(), hashmap_of_numbers_2.clone()),
+    ]);
+
+    // Test valid set
+    let test_struct = TestStruct {
+        hashmap_of_hashmap: hashmap_of_hashmap.clone(),
+        hashmap_of_numbers: hashmap_of_numbers.clone(),
+        hashmap_of_strings: hashmap_of_strings.clone(),
+    };
+    assert!(test_struct.validate().is_ok());
+
+    // Test invalid set
+    hashmap_of_numbers.insert("twenty".to_string(), 20);
+    hashmap_of_strings.insert("three".to_string(), "ff".to_string());
+    hashmap_of_numbers_2.insert("nineteen".to_string(), 19);
+    hashmap_of_hashmap.insert("H_three".to_string(), hashmap_of_numbers_2);
+    let test_struct2 = TestStruct {
+        hashmap_of_hashmap,
+        hashmap_of_numbers,
+        hashmap_of_strings,
+    };
+
+    // Because hashmap indexing is non-deterministic,
+    // we have to check for the individual errors returned.
+    let errors = test_struct2.validate().unwrap_err().to_string();
+    assert_eq!(
+        // This should appear for all 3 hashmaps.
+        Regex::new(r"The size of the properties must be `<= 2`\.")
+            .unwrap()
+            .find_iter(&errors)
+            .count(),
+        3
+    );
+    assert!(errors.contains("The value must be multiple of `5`."));
+    assert!(errors.contains(
+        &json!({"errors":[
+        "The value must match the pattern of \"d.*\".",
+        "The length of the value must be `>= 5`."
+        ]})
+        .to_string()
+    ));
+    assert!(errors.contains(
+        &json!({"errors":[
+            "The value must be in [5, 10, 15].",
+            "The number must be `<= 10`.",
+            "The number must be `< 11`."
+        ]})
+        .to_string()
+    ));
+}


### PR DESCRIPTION
This solves issue #7 that I raised: https://github.com/yassun4dev/serde_valid/issues/7

Fundamentally, I applied a modified version of the compositedTrait impl of Vec to Hashmaps, checking the values inside the HashMap.

I add a new macro invocation for creating the impls that is only called on the string validations that allows the values in a hashMap to be validated against. This keeps the impls of validate on hashmap for max/min properties unchanged as checking len is clearly still what is wanted there.

I also add the same recursive Value validation of hashmaps to the rest of the impls that have <T> - numbers etc. These were simple and simply worked.

Finally, I added a test for this new impl. Unfortunately for the error case there I couldn't just check the full json output due to the need to return the index from the compositedTrait impl and the fact that HashMaps are not ordered, so I check the errors separately instead, making sure that errors that appear multiple times appear the correct number of times.