### PR TITLE
Return to arrayErrors to make hashmap validation work properly again

### DIFF
--- a/serde_valid/src/lib.rs
+++ b/serde_valid/src/lib.rs
@@ -504,24 +504,24 @@ where
     }
 }
 
-impl<V> Validate for HashMap<&'static str, V>
+impl<K, V> Validate for HashMap<K, V>
 where
     V: Validate,
 {
     fn validate(&self) -> std::result::Result<(), self::validation::Errors> {
         let mut items = IndexMap::new();
 
-        for (key, value) in self.iter() {
+        for (index, (_key, value)) in self.iter().enumerate() {
             if let Err(errors) = value.validate() {
-                items.insert(*key, errors);
+                items.insert(index, errors);
             }
         }
 
         if items.is_empty() {
             Ok(())
         } else {
-            Err(self::validation::Errors::Object(
-                validation::ObjectErrors::new(vec![], items),
+            Err(self::validation::Errors::Array(
+                validation::ArrayErrors::new(vec![], items),
             ))
         }
     }

--- a/serde_valid/tests/hashmap_test.rs
+++ b/serde_valid/tests/hashmap_test.rs
@@ -38,6 +38,18 @@ struct TestStruct {
     hashmap_of_strings: HashMap<String, String>,
 }
 
+#[derive(Debug, Validate)]
+struct DeriveValidateHashmap {
+    #[validate]
+    hashmap_of_object: HashMap<String, Object>,
+}
+
+#[derive(Debug, Validate)]
+struct Object {
+    #[validate(maximum = 5)]
+    number: i32,
+}
+
 #[test]
 fn hashmap_validation() {
     // Create basic valid hashmaps.
@@ -99,4 +111,42 @@ fn hashmap_validation() {
         ]})
         .to_string()
     ));
+}
+
+#[test]
+fn hashmap_object_validation() {
+    let object = Object { number: 5 };
+    let hashmap_of_object = HashMap::from([("object".to_string(), object)]);
+    let test_struct = DeriveValidateHashmap {
+        hashmap_of_object: hashmap_of_object,
+    };
+    assert!(test_struct.validate().is_ok());
+
+    let object2 = Object { number: 6 };
+    let hashmap_of_object2 = HashMap::from([("object".to_string(), object2)]);
+    let test_struct2 = DeriveValidateHashmap {
+        hashmap_of_object: hashmap_of_object2,
+    };
+    assert_eq!(
+        test_struct2.validate().unwrap_err().to_string(),
+        json!({"errors":[],
+        "properties":{
+            "hashmap_of_object":{
+                "errors":[],
+                "items":{
+                    "0":{
+                        "errors":[],
+                        "properties":{
+                            "number":{
+                                "errors":
+                                ["The number must be `<= 5`."]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+        .to_string()
+    );
 }


### PR DESCRIPTION
Sorry to do this, but I can't figure out a way of making this work without a large rewrite of the error-handling and I simply can't figure out this codebase well enough. But better to have this working and a bit naff than not working at all.